### PR TITLE
Modify Docusaurus resource bash path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,14 @@ on:
       - master
 
 jobs:
+  test:
+    uses: ./.github/workflows/test-deploy.yml
+    secrets: inherit
+
   deploy:
     name: Deploy to GitHub Pages
-    runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
+    needs: test
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,6 +1,7 @@
 name: Test deployment
 
 on:
+  workflow_call:
   pull_request:
     branches:
       - master
@@ -8,7 +9,7 @@ on:
 jobs:
   test-deploy:
     name: Test deployment
-    runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,13 +5,13 @@ const katex = require('rehype-katex');
 module.exports = {
   title: "Memgraph Docs",
   tagline: "Welcome to the Memgraph Docs site!",
-  url: "https://memgraph.com",
-  baseUrl,
-  onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
+  url: "https://QubitPi.github.io/",
+  baseUrl: "/memgraph-docs/",
+  onBrokenLinks: "warn",         // setting this to warn is actually OK, otherwise image redirect fails the build
+  onBrokenMarkdownLinks: "warn", // setting this to warn is actually OK, otherwise image redirect fails the build
   favicon: "img/social-logo-round-corners.png",
-  organizationName: "memgraph",
-  projectName: "docs",
+  organizationName: "QubtiPi",
+  projectName: "memgraph-docs",
   stylesheets: [
     "https://fonts.googleapis.com/css?family=Encode+Sans+Condensed:500,600",
     "https://fonts.googleapis.com/css?family=Roboto:400, 500,600",
@@ -1313,7 +1313,7 @@ module.exports = {
             to: "/memgraph/reference-guide/transactions",
             from: ["/memgraph/reference-guide/isolation-levels"],
           },
-          // Redirect for the Import section 
+          // Redirect for the Import section
           {
             to: "/memgraph/import-data/files/load-json",
             from: ["/memgraph/import-data/load-json", "/memgraph/import-data/json/load-json"],


### PR DESCRIPTION
### Description

- Change CI/CI machine image to to ubuntu only, because [other images failed to trigger the GitHub Actions](https://stackoverflow.com/questions/71027513/all-github-action-jobs-are-queued-and-never-running)
- Add CI/CD dependency: release process starts only after test phase passes
- Modified Docusaurus.config.js

  - Change domain to `QubitPi.github.io`
  - Prefix all page with `/memgraph-docs/`, the forked repo name
  - Suppress false-negative error on broken link detection

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [ ] Documentation fix
- [ ] New documentation page 
- [ ] Base PR for the release
- [ ] Documentation improvements
- [x] Other (please describe): Deploy documentation to a different GitHub Pages

### Related PRs and issues

PR this doc page is related to: 
Closes (link to issue):


### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
